### PR TITLE
Fix compare links in changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0](https://github.com/patrik-csak/terminal-profile/compare/v3.0.2...v4.0.0) – 2024-03-25
+## [4.0.0](https://github.com/patrik-csak/auto-terminal-profile/compare/v3.0.2...v4.0.0) – 2024-03-25
 
 ### Added
 
@@ -15,19 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: `update-profile` gets appearance mode from OS instead of from `DARKMODE` environment variable
 
-## [3.0.2](https://github.com/patrik-csak/terminal-profile/compare/v3.0.1...v3.0.2) – 2024-02-21
+## [3.0.2](https://github.com/patrik-csak/auto-terminal-profile/compare/v3.0.1...v3.0.2) – 2024-02-21
 
 ### Fixed
 
 - Fix Terminal opening when closed
 
-## [3.0.1](https://github.com/patrik-csak/terminal-profile/compare/v3.0.0...v3.0.1) – 2024-02-20
+## [3.0.1](https://github.com/patrik-csak/auto-terminal-profile/compare/v3.0.0...v3.0.1) – 2024-02-20
 
 ### Fixed
 
 - Fix broken post-install compilation step
 
-## [3.0.0](https://github.com/patrik-csak/terminal-profile/compare/v2.1.0...v3.0.0) – 2024-02-19
+## [3.0.0](https://github.com/patrik-csak/auto-terminal-profile/compare/v2.1.0...v3.0.0) – 2024-02-19
 
 ### Changed
 
@@ -41,13 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issue causing `auto-terminal-profile` to silently fail on macOS Sonoma
 
-## [2.1.0](https://github.com/patrik-csak/terminal-profile/compare/v2.0.0...v2.1.0) – 2023-07-04
+## [2.1.0](https://github.com/patrik-csak/auto-terminal-profile/compare/v2.0.0...v2.1.0) – 2023-07-04
 
 ### Changed
 
 - Update dependencies
 
-## [2.0.0](https://github.com/patrik-csak/terminal-profile/compare/v1.1.1...v2.0.0) – 2023-05-10
+## [2.0.0](https://github.com/patrik-csak/auto-terminal-profile/compare/v1.1.1...v2.0.0) – 2023-05-10
 
 ### Added
 


### PR DESCRIPTION
Was linking to https://github.com/patrik-csak/terminal-profile as opposed to https://github.com/patrik-csak/auto-terminal-profile